### PR TITLE
Enable CORS and use absolute API URLs

### DIFF
--- a/src/main/java/com/mycompany/myapp/web/rest/AiCodegenResource.java
+++ b/src/main/java/com/mycompany/myapp/web/rest/AiCodegenResource.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Map;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:4200")
 @RequestMapping("/api/ai")
 public class AiCodegenResource {
 

--- a/src/main/java/com/mycompany/myapp/web/rest/GeneratedComponentResource.java
+++ b/src/main/java/com/mycompany/myapp/web/rest/GeneratedComponentResource.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 
 @RestController
+@CrossOrigin(origins = "http://localhost:4200")
 @RequestMapping("/api/generated-components")
 public class GeneratedComponentResource {
 

--- a/src/main/webapp/app/ai/codegen/ai-codegen.service.ts
+++ b/src/main/webapp/app/ai/codegen/ai-codegen.service.ts
@@ -12,10 +12,10 @@ export class AiCodegenService {
   constructor(private http: HttpClient) {}
 
   generate(prompt: string): Observable<GeneratedCode> {
-    return this.http.post<GeneratedCode>('/api/ai/codegen', { prompt });
+    return this.http.post<GeneratedCode>('http://localhost:8080/api/ai/codegen', { prompt });
   }
 
   save(component: any) {
-    return this.http.post('/api/generated-components', component);
+    return this.http.post('http://localhost:8080/api/generated-components', component);
   }
 }


### PR DESCRIPTION
## Summary
- allow cross origin requests from Angular dev server
- call the backend using full API URLs in Angular service

## Testing
- `mvn -q test` *(fails: mvn not found)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685ec1c76ce0832fb3bbf58a7b0f8a87